### PR TITLE
Add separate speed parameters for approach_block and aim_block

### DIFF
--- a/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
@@ -2,8 +2,10 @@
 robot.logger:register_module('api_parameters')
 
 return {
-    default_speed = tonumber(robot.params.default_speed or 0.005),
-    default_turn_speed = tonumber(robot.params.default_turn_speed or 5),
+    default_speed = tonumber(robot.params.default_speed or 0.020),
+    default_turn_speed = tonumber(robot.params.default_turn_speed or 7),
+    approach_block_speed = tonumber(robot.params.approach_block_speed or 0.01),
+    approach_block_turn_speed = tonumber(robot.params.approach_block_turn_speed or 5),
     search_random_range = tonumber(robot.params.search_random_range or 25),
     aim_block_angle_tolerance = tonumber(robot.params.aim_block_angle_tolerance or 0.5),
     block_position_tolerance = tonumber(robot.params.block_position_tolerance or 0.001),

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/aim_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/aim_block.lua
@@ -70,12 +70,12 @@ return function(data, aim_point)
 
       local base_speed = 0
       if aim_point.forward_backup == "forward" then
-         base_speed = robot.api.parameters.default_speed 
+         base_speed = robot.api.parameters.approach_block_speed 
       elseif aim_point.forward_backup == "backup" then
-         base_speed = -robot.api.parameters.default_speed 
+         base_speed = -robot.api.parameters.approach_block_speed 
       end
 
-      robot.api.move.with_bearing(base_speed, robot.api.parameters.default_turn_speed * err)
+      robot.api.move.with_bearing(base_speed, robot.api.parameters.approach_block_turn_speed * err)
 
       if current_pixel < target_pixel - pixel_tolerance or
          current_pixel > target_pixel + pixel_tolerance then

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/curved_approach_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/curved_approach_block.lua
@@ -98,7 +98,7 @@ return function(data, target_distance)
          function()
             local target_block = data.blocks[data.target.id]
             local tolerence = robot.api.parameters.block_position_tolerance
-            local default_speed = robot.api.parameters.default_speed
+            local default_speed = robot.api.parameters.approach_block_speed
             if case.forward_backup_case == 1 then
                -- forward case
                --if target_block.position_robot.x > target_distance - tolerence then


### PR DESCRIPTION
The Builderbot is basically working. I added separate speed parameters for approach because sometimes the default speed is too fast for aiming, the builderbot may lose the block or shaking its head due to over adjustment.