### PR TITLE
Changes according to hardware experiments

### DIFF
--- a/src/plugins/robots/builderbot/control_interface/lua/api/constants.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/api/constants.lua
@@ -16,5 +16,4 @@ return {
     end_effector_position_offset = vector3(0.09800875, 0, 0.055),
     end_effector_position_pickup_bias = 0.002, -- move less when picking up a block
     end_effector_position_place_bias = 0.002, -- secure distance above ground when placing a block
-    end_effector_nose_length = 0.005,
 }

--- a/src/plugins/robots/builderbot/control_interface/lua/api/constants.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/api/constants.lua
@@ -15,5 +15,6 @@ return {
     lift_system_lower_limit = 0,
     end_effector_position_offset = vector3(0.09800875, 0, 0.055),
     end_effector_position_pickup_bias = 0.002, -- move less when picking up a block
+    end_effector_position_place_bias = 0.002, -- secure distance above ground when placing a block
     end_effector_nose_length = 0.005,
 }

--- a/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
@@ -19,5 +19,6 @@ return {
     z_approach_range_angle = tonumber(robot.params.z_approach_range_angle or 20),
     z_approach_range_distance = tonumber(robot.params.z_approach_range_distance or 0.27),
     z_approach_block_distance_increment = tonumber(robot.params.z_approach_block_distance_increment or 0.10),
+    end_effector_nose_length = tonumber(robot.params.end_effector_nose_length or 0.005),
 }
 

--- a/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/api/parameters.lua
@@ -19,6 +19,6 @@ return {
     z_approach_range_angle = tonumber(robot.params.z_approach_range_angle or 20),
     z_approach_range_distance = tonumber(robot.params.z_approach_range_distance or 0.27),
     z_approach_block_distance_increment = tonumber(robot.params.z_approach_block_distance_increment or 0.10),
-    end_effector_nose_length = tonumber(robot.params.end_effector_nose_length or 0.005),
+    end_effector_overhang_length = tonumber(robot.params.end_effector_overhang_length or 0.005),
 }
 

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/place_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/place_block.lua
@@ -27,6 +27,12 @@ return function(data, forward_distance)
          end,
          -- wait for 2 sec
          robot.nodes.create_timer_node(2),
+         function()
+            robot.lift_system.set_position(robot.lift_system.position + 0.05)
+            return false, true
+         end,
+         -- wait for 2 sec
+         robot.nodes.create_timer_node(2),
          -- recharge magnet
          function()
             robot.electromagnet_system.set_discharge_mode("disable")

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
@@ -82,7 +82,7 @@ return function(data, distance)
                      robot.nodes.create_timer_node(
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
-                        robot.api.parameters.end_effector_nose_length
+                        robot.api.parameters.end_effector_overhang_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -136,7 +136,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.parameters.end_effector_nose_length
+                        robot.api.parameters.end_effector_overhang_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -162,7 +162,7 @@ return function(data, distance)
                      function()
                         robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z - 
                                                       robot.api.constants.block_side_length - 
-                                                      robot.api.parameters.end_effector_nose_length) 
+                                                      robot.api.parameters.end_effector_overhang_length) 
                         return false, true
                      end,
                      -- check whether lift to position
@@ -175,7 +175,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.parameters.end_effector_nose_length
+                        robot.api.parameters.end_effector_overhang_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -212,7 +212,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.parameters.end_effector_nose_length
+                        robot.api.parameters.end_effector_overhang_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
@@ -69,7 +69,8 @@ return function(data, distance)
                      end,
                      -- raise lift
                      function()
-                        robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z + robot.api.constants.block_side_length) 
+                        robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z + 
+                                                       robot.api.constants.block_side_length) 
                         return false, true
                      end,
                      -- check whether lift to position
@@ -87,7 +88,21 @@ return function(data, distance)
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
                                                       robot.api.parameters.default_speed)
                         end
-                     )
+                     ),
+                     function() robot.api.move.with_velocity(0,0) return false, true end,
+
+                     function()
+                        robot.lift_system.set_position(robot.lift_system.position -
+								                       robot.api.constants.block_side_length / 2)
+                        return false, true
+                     end,
+                     -- wait for 2 sec
+                     robot.nodes.create_timer_node(0.5),
+                     -- check whether lift to position
+                     function()
+                        if robot.lift_system.state == "inactive" then return false, true
+                        else return true end
+                     end
                   },
                },
                -- reach the front of the reference block
@@ -104,9 +119,13 @@ return function(data, distance)
                      end,
                      -- raise lift
                      function()
-                        robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z) 
+                        robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z - 
+                                                       robot.api.constants.block_side_length / 2 +
+                                                       robot.api.constants.end_effector_position_place_bias) 
                         return false, true
                      end,
+                     -- wait for 2 sec
+                     robot.nodes.create_timer_node(0.5),
                      -- check whether lift to position
                      function()
                         if robot.lift_system.state == "inactive" then return false, true
@@ -123,7 +142,8 @@ return function(data, distance)
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
                                                       robot.api.parameters.default_speed)
                         end
-                     )
+                     ),
+                     function() robot.api.move.with_velocity(0,0) return false, true end,
                   },
                },
                -- reach the front down of the reference block

--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/reach_block.lua
@@ -82,7 +82,7 @@ return function(data, distance)
                      robot.nodes.create_timer_node(
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
-                        robot.api.constants.end_effector_nose_length
+                        robot.api.parameters.end_effector_nose_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -136,7 +136,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.constants.end_effector_nose_length
+                        robot.api.parameters.end_effector_nose_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -162,7 +162,7 @@ return function(data, distance)
                      function()
                         robot.lift_system.set_position(data.blocks[data.target.id].position_robot.z - 
                                                       robot.api.constants.block_side_length - 
-                                                      robot.api.constants.end_effector_nose_length) 
+                                                      robot.api.parameters.end_effector_nose_length) 
                         return false, true
                      end,
                      -- check whether lift to position
@@ -175,7 +175,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.constants.end_effector_nose_length
+                        robot.api.parameters.end_effector_nose_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 
@@ -212,7 +212,7 @@ return function(data, distance)
                         (distance - 
                         robot.api.constants.end_effector_position_offset.x - 
                         robot.api.constants.block_side_length - 
-                        robot.api.constants.end_effector_nose_length
+                        robot.api.parameters.end_effector_nose_length
                         ) / robot.api.parameters.default_speed,
                         function()
                            robot.api.move.with_velocity(robot.api.parameters.default_speed, 


### PR DESCRIPTION
1. Change Builderbot reach and place behavior, to make the Builderbot release the free block after the newly assembled block touching the structure. This requires the Builderbot lower down the manipulator a bit before place the block on the top and move forward a bit before place a block in the front.
2. Change Builderbot constant end_effector_nose_length into a parameter for the hardware experiment of a cross.