### PR TITLE
1. pipuck software calibration.  2. Builderbot bt node bug fix

### DIFF
--- a/src/plugins/robots/builderbot/control_interface/lua/nodes/aim_block.lua
+++ b/src/plugins/robots/builderbot/control_interface/lua/nodes/aim_block.lua
@@ -60,8 +60,11 @@ return function(data, aim_point)
          current_pixel = target_tag.corners.right
          target_pixel = right_target_pixel
       else
-         current_pixel = target_tag.center.x
-         target_pixel = middle_target_pixel
+         local tag_to_endeffector = vector3(target_tag.position):rotate(robot.camera_system.transform.orientation)
+                                    + robot.camera_system.transform.position
+         current_pixel = -math.atan(tag_to_endeffector.y / tag_to_endeffector.x) * 180 / math.pi
+         target_pixel = 0
+         pixel_tolerance = robot.api.parameters.aim_block_angle_tolerance * 2
       end
 
       local err = (target_pixel - current_pixel) / pixel_tolerance

--- a/src/plugins/robots/builderbot/simulator/dynamics3d_builderbot_model.cpp
+++ b/src/plugins/robots/builderbot/simulator/dynamics3d_builderbot_model.cpp
@@ -297,8 +297,8 @@ namespace argos {
    
    void CDynamics3DBuilderBotModel::UpdateEntityStatus() {
       /* write current wheel speeds back to the simulation */
-      m_cDifferentialDriveEntity.SetVelocityLeft(m_cMultiBody.getJointVel(m_ptrLeftWheel->GetIndex() * m_cWheelHalfExtents.getX()));
-      m_cDifferentialDriveEntity.SetVelocityRight(m_cMultiBody.getJointVel(m_ptrRightWheel->GetIndex() * m_cWheelHalfExtents.getX()));
+      m_cDifferentialDriveEntity.SetVelocityLeft(m_cMultiBody.getJointVel(m_ptrLeftWheel->GetIndex()) * m_cWheelHalfExtents.getX());
+      m_cDifferentialDriveEntity.SetVelocityRight(m_cMultiBody.getJointVel(m_ptrRightWheel->GetIndex()) * m_cWheelHalfExtents.getX());
       /* run the base class's implementation of this method */
       CDynamics3DMultiBodyObjectModel::UpdateEntityStatus();
    }

--- a/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.cpp
+++ b/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.cpp
@@ -191,11 +191,11 @@ namespace argos {
    /****************************************/
 
    const btVector3    CDynamics3DPiPuckModel::m_cBodyHalfExtents(0.0362, 0.069, 0.0362);
-   const btScalar     CDynamics3DPiPuckModel::m_fBodyMass(0.242);
+   const btScalar     CDynamics3DPiPuckModel::m_fBodyMass(0.001);
    const btTransform  CDynamics3DPiPuckModel::m_cBodyOffset(btQuaternion(0.0, 0.0, 0.0, 1.0), btVector3(0.0,0.00125,0.0));
    const btTransform  CDynamics3DPiPuckModel::m_cBodyGeometricOffset(btQuaternion(0.0, 0.0, 0.0, 1.0), btVector3(0.0, -0.069, 0.0));
-   const btVector3    CDynamics3DPiPuckModel::m_cWheelHalfExtents(0.02125, 0.0015, 0.02125);
-   const btScalar     CDynamics3DPiPuckModel::m_fWheelMass(0.006);
+   const btVector3    CDynamics3DPiPuckModel::m_cWheelHalfExtents(0.02125, 0.0055, 0.02125);
+   const btScalar     CDynamics3DPiPuckModel::m_fWheelMass(0.1265);
    const btTransform  CDynamics3DPiPuckModel::m_cWheelGeometricOffset(btQuaternion(0.0, 0.0, 0.0, 1.0), btVector3(0.0, -0.0015, 0.0));
    const btTransform  CDynamics3DPiPuckModel::m_cLeftWheelOffset(btQuaternion(btVector3(-1,0,0), SIMD_HALF_PI), btVector3(0.0, 0.02125, -0.0255));
    const btTransform  CDynamics3DPiPuckModel::m_cRightWheelOffset(btQuaternion(btVector3(1,0,0), SIMD_HALF_PI), btVector3(0.0, 0.02125, 0.0255));
@@ -208,9 +208,9 @@ namespace argos {
    /* TODO calibrate these values */
    const btScalar     CDynamics3DPiPuckModel::m_fBodyFriction(0.0);
    const btScalar     CDynamics3DPiPuckModel::m_fWheelMotorMaxImpulse(0.05);
-   const btScalar     CDynamics3DPiPuckModel::m_fWheelFriction(0.75);
-   const btScalar     CDynamics3DPiPuckModel::m_fWheelMotorClamp(2.0);
-   const btScalar     CDynamics3DPiPuckModel::m_fWheelMotorKdCoefficient(0.9);
+   const btScalar     CDynamics3DPiPuckModel::m_fWheelFriction(10);
+   const btScalar     CDynamics3DPiPuckModel::m_fWheelMotorClamp(5.0);
+   const btScalar     CDynamics3DPiPuckModel::m_fWheelMotorKdCoefficient(2.0);
 
    /****************************************/
    /****************************************/

--- a/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.cpp
+++ b/src/plugins/robots/pi-puck/simulator/dynamics3d_pipuck_model.cpp
@@ -141,8 +141,8 @@ namespace argos {
    
    void CDynamics3DPiPuckModel::UpdateEntityStatus() {
       /* write current wheel speeds back to the simulation */
-      m_cDifferentialDriveEntity.SetVelocityLeft(m_cMultiBody.getJointVel(m_ptrLeftWheel->GetIndex() * m_cWheelHalfExtents.getX()));
-      m_cDifferentialDriveEntity.SetVelocityRight(m_cMultiBody.getJointVel(m_ptrRightWheel->GetIndex() * m_cWheelHalfExtents.getX()));
+      m_cDifferentialDriveEntity.SetVelocityLeft(m_cMultiBody.getJointVel(m_ptrLeftWheel->GetIndex()) * m_cWheelHalfExtents.getX());
+      m_cDifferentialDriveEntity.SetVelocityRight(m_cMultiBody.getJointVel(m_ptrRightWheel->GetIndex()) * m_cWheelHalfExtents.getX());
       /* run the base class's implementation of this method */
       CDynamics3DMultiBodyObjectModel::UpdateEntityStatus();
    }


### PR DESCRIPTION
1. Calibrate dynamics3d pipuck model for pipuck differential drive system simulation
2. Improve aim_block bt node to fix inaccurate aiming when builderbot camera is biased