### PR TITLE
Flip tags in drone camera simulation to match reality

### DIFF
--- a/src/plugins/robots/builderbot/simulator/builderbot_camera_system_default_sensor.cpp
+++ b/src/plugins/robots/builderbot/simulator/builderbot_camera_system_default_sensor.cpp
@@ -297,7 +297,7 @@ namespace argos {
       /* TODO: Update the position and orientation calculations to avoid the use of matrices */
       CVector3 cTagPosition = m_cCameraToWorldTransform * c_tag.GetPosition();
       /* Direction of the tag should be pointing inside of the tag */
-      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation() * CQuaternion(CRadians(M_PI), CVector3(1,0,0));
+      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation() * CQuaternion(CRadians::PI, CVector3::X);
       /* transfer readings to the control interface */
       m_tTags.emplace_back(unId, cTagPosition, cTagOrientation, cCenterPixel, m_arrTagCornerPixels);
       return true;

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
@@ -330,7 +330,7 @@ namespace argos {
       /* TODO: Update the position and orientation calculations to avoid the use of matrices */
       CVector3 cTagPosition = m_cCameraToWorldTransform * c_tag.GetPosition();
       /* Direction of the tag should be pointing inside of the tag */
-      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation() * CQuaternion(CRadians(M_PI), CVector3(1,0,0));
+      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation() * CQuaternion(CRadians::PI, CVector3::X);
       /* transfer readings to the control interface */
       Tags.emplace_back(unId, cTagPosition, cTagOrientation, cCenterPixel, m_arrTagCornerPixels);
       return true;

--- a/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/simulator/drone_cameras_system_default_sensor.cpp
@@ -329,7 +329,8 @@ namespace argos {
       catch(const std::logic_error& err_logic) {}
       /* TODO: Update the position and orientation calculations to avoid the use of matrices */
       CVector3 cTagPosition = m_cCameraToWorldTransform * c_tag.GetPosition();
-      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation();
+      /* Direction of the tag should be pointing inside of the tag */
+      CQuaternion cTagOrientation = m_cCameraOrientation.Inverse() * c_tag.GetOrientation() * CQuaternion(CRadians(M_PI), CVector3(1,0,0));
       /* transfer readings to the control interface */
       Tags.emplace_back(unId, cTagPosition, cTagOrientation, cCenterPixel, m_arrTagCornerPixels);
       return true;


### PR DESCRIPTION
Apriltag considers tag orientation pointing inside the tag, so in drone simulation we should flip the tag, as we have done for builderbots.